### PR TITLE
feature: Add multi-account support with secure credential storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,24 @@ It helps you keep track of builds, inspect logs, and understand pipeline status 
 
 ## Get started
 
-To start using Azure Pipelines Runner, you only need an Azure DevOps organization and a Personal Access Token (PAT).
+To start using Azure Pipelines Runner, simply add your Azure DevOps account through the Accounts view.
 
-Once configured, the extension will automatically load your projects, pipelines, and builds into the VS Code Explorer.
+You'll need:
+- Your Azure DevOps organization name
+- A Personal Access Token (PAT)
+
+Once added, the extension will automatically load your projects, pipelines, and builds into the VS Code Explorer.
+
+---
+
+## Manage multiple accounts
+
+Azure Pipelines Runner supports multiple Azure DevOps accounts:
+
+- Add accounts through the Accounts view in the Explorer
+- Switch between accounts to view different organizations
+- Credentials are stored securely using VS Code's Secret Storage
+- Legacy credentials from `settings.json` are automatically migrated to secure storage
 
 ---
 
@@ -57,14 +72,9 @@ To use this extension, you will need:
 
 ## Extension settings
 
-The following settings are required to configure the extension:
+No manual configuration in `settings.json` is required. Accounts are managed through the Accounts view in the Explorer.
 
-```json
-{
-  "azurePipelinesRunner.organization": "your-organization",
-  "azurePipelinesRunner.pat": "your-personal-access-token"
-}
-```
+**Note:** If you previously configured credentials in `settings.json`, they will be automatically migrated to secure storage when the extension activates.
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "azure-pipeline-runner",
-  "version": "0.0.5",
+  "version": "0.0.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "azure-pipeline-runner",
-      "version": "0.0.5",
+      "version": "0.0.8",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.7.7",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,10 @@
     "views": {
       "azurePipelinesRunner": [
         {
+          "id": "azurePipelineAccounts",
+          "name": "Accounts"
+        },
+        {
           "id": "azurePipelineView",
           "name": "Pipelines",
           "when": "true"
@@ -135,10 +139,44 @@
         "command": "azurePipelinesRunner.retriggerBuild",
         "title": "Retrigger Build",
         "icon": "$(debug-restart)"
+      },
+      {
+        "command": "azurePipelinesRunner.addAccount",
+        "title": "Add Account",
+        "icon": "$(add)"
+      },
+      {
+        "command": "azurePipelinesRunner.switchAccount",
+        "title": "Switch Account"
+      },
+      {
+        "command": "azurePipelinesRunner.editAccountNote",
+        "title": "Edit Note",
+        "icon": "$(edit)"
+      },
+      {
+        "command": "azurePipelinesRunner.deleteAccount",
+        "title": "Delete Account",
+        "icon": "$(trash)"
+      },
+      {
+        "command": "azurePipelinesRunner.refreshAccounts",
+        "title": "Refresh Accounts",
+        "icon": "$(refresh)"
       }
     ],
     "menus": {
       "view/title": [
+        {
+          "command": "azurePipelinesRunner.addAccount",
+          "when": "view == azurePipelineAccounts",
+          "group": "navigation@1"
+        },
+        {
+          "command": "azurePipelinesRunner.refreshAccounts",
+          "when": "view == azurePipelineAccounts",
+          "group": "navigation@2"
+        },
         {
           "command": "azurePipelinesRunner.refreshEntry",
           "when": "view == azurePipelineView",
@@ -166,6 +204,16 @@
         }
       ],
       "view/item/context": [
+        {
+          "command": "azurePipelinesRunner.editAccountNote",
+          "when": "viewItem == account || viewItem == account-active",
+          "group": "inline@1"
+        },
+        {
+          "command": "azurePipelinesRunner.deleteAccount",
+          "when": "viewItem == account || viewItem == account-active",
+          "group": "inline@2"
+        },
         {
           "command": "azurePipelinesRunner.openPipeline",
           "when": "viewItem == pipeline",
@@ -196,25 +244,13 @@
     "viewsWelcome": [
       {
         "view": "azurePipelineView",
-        "contents": "Welcome to Azure Pipelines Runner!\n\nTo get started, provide your Azure DevOps organization name and a Personal Access Token (PAT).\n\nThe PAT should have the following scopes:\n- Build (Read & Execute)\n- Code (Read)\n- Release (Read, Write, Execute, & Manage)\n\n[Configure](command:azurePipelinesRunner.showWelcome)\n\n[Refresh](command:azurePipelinesRunner.refreshEntry)",
-        "when": "azurePipelinesRunner.showWelcome == false"
+        "contents": "Welcome to Azure Pipelines Runner!\n\nTo get started, add your Azure DevOps account in the Accounts pane above.\n\nThe PAT should have the following scopes:\n- Build (Read & Execute)\n- Code (Read)\n- Release (Read, Write, Execute, & Manage)\n\n[Add Account](command:azurePipelinesRunner.addAccount)\n\n[Refresh](command:azurePipelinesRunner.refreshEntry)"
       }
     ],
     "configuration": {
       "type": "object",
       "title": "Azure Pipelines Runner",
-      "properties": {
-        "azurePipelinesRunner.organization": {
-          "type": "string",
-          "default": "",
-          "description": "Azure DevOps organization name"
-        },
-        "azurePipelinesRunner.pat": {
-          "type": "string",
-          "default": "",
-          "description": "Personal Access Token (PAT) for Azure DevOps"
-        }
-      }
+      "properties": {}
     }
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -243,8 +243,20 @@
     },
     "viewsWelcome": [
       {
+        "view": "azurePipelineAccounts",
+        "contents": "No Azure DevOps accounts connected yet.\n\nConnect your Azure DevOps organization to browse pipelines, builds, and stages directly from VS Code.\n\nGet started:\n\n[Add your first account](command:azurePipelinesRunner.addAccount)\n\n---\n\nRequired PAT scopes:\n\n• Build — Read & Execute\n• Code — Read\n• Release — Read, Write, Execute & Manage\n\n[Learn more](https://github.com/pedroccaetano/azure-pipeline-runner)\n"
+      },
+      {
         "view": "azurePipelineView",
-        "contents": "Welcome to Azure Pipelines Runner!\n\nTo get started, add your Azure DevOps account in the Accounts pane above.\n\nThe PAT should have the following scopes:\n- Build (Read & Execute)\n- Code (Read)\n- Release (Read, Write, Execute, & Manage)\n\n[Add Account](command:azurePipelinesRunner.addAccount)\n\n[Refresh](command:azurePipelinesRunner.refreshEntry)"
+        "contents": "No pipelines available.\n\nConnect an account or select a different Azure DevOps project."
+      },
+      {
+        "view": "azurePipelineBuilds",
+        "contents": "No builds to display.\n\nSelect a pipeline from the Pipelines view above to see its builds."
+      },
+      {
+        "view": "azurePipelineStages",
+        "contents": "No stages to display.\n\nSelect a build from the Builds view above to view its stages."
       }
     ],
     "configuration": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "publisher": "PedroCaetano",
   "icon": "resources/icon.png",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "license": "MIT",
   "homepage": "https://github.com/your-username/azure-pipeline-runner#readme",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "azure-pipeline-runner",
   "displayName": "Azure Pipelines Runner",
-  "description": "Azure DevOps pipelines and builds in your VS Code",
+  "description": "Run, monitor, and explore Azure DevOps pipelines directly in VS Code",
   "author": {
     "name": "Pedro Caetano",
     "email": "pedrohenriquedecaldascaetano@gmail.com"
@@ -10,7 +10,7 @@
   "icon": "resources/icon.png",
   "version": "0.0.8",
   "license": "MIT",
-  "homepage": "https://github.com/your-username/azure-pipeline-runner#readme",
+  "homepage": "https://github.com/pedroccaetano/azure-pipeline-runner#readme",
   "repository": {
     "type": "git",
     "url": "https://github.com/pedroccaetano/azure-pipeline-runner.git"
@@ -23,8 +23,16 @@
   },
   "categories": [
     "Azure",
-    "Visualization",
+    "SCM Providers",
     "Other"
+  ],
+  "keywords": [
+    "azure devops",
+    "pipelines",
+    "ci cd",
+    "builds",
+    "devops",
+    "azure pipelines"
   ],
   "activationEvents": [
     "onView:azurePipelinesRunner.azurePipelineView",

--- a/src/commands/register-commands.ts
+++ b/src/commands/register-commands.ts
@@ -33,7 +33,10 @@ export function registerCommands(
   accountTreeDataProvider: AccountTreeDataProvider,
   pipelineTreeDataProvider: PipelineTreeDataProvider,
   buildTreeDataProvider: BuildTreeDataProvider,
-  stageTreeDataProvider: StageTreeDataProvider
+  stageTreeDataProvider: StageTreeDataProvider,
+  pipelinesTreeView?: vscode.TreeView<unknown>,
+  buildsTreeView?: vscode.TreeView<unknown>,
+  stagesTreeView?: vscode.TreeView<unknown>
 ) {
   // Account Commands
   context.subscriptions.push(
@@ -98,6 +101,15 @@ export function registerCommands(
           // Refresh all views
           accountTreeDataProvider.refresh();
           pipelineTreeDataProvider.refresh();
+
+          // Expand and focus Pipelines view
+          if (pipelinesTreeView) {
+            try {
+              await vscode.commands.executeCommand("azurePipelineView.focus");
+            } catch (error) {
+              // Silently fail if command doesn't work
+            }
+          }
           buildTreeDataProvider.refresh();
           stageTreeDataProvider.refresh();
         } catch (error) {
@@ -332,6 +344,15 @@ export function registerCommands(
       async ({ builds, project }: { builds: Build[]; project: Project }) => {
         const build = builds[0];
         await stageTreeDataProvider.loadStages(build, project);
+        
+        // Expand and focus Stages view
+        if (stagesTreeView) {
+          try {
+            await vscode.commands.executeCommand("azurePipelineStages.focus");
+          } catch (error) {
+            // Silently fail if command doesn't work
+          }
+        }
       }
     )
   );
@@ -349,6 +370,15 @@ export function registerCommands(
         stageTreeDataProvider.refresh();
         buildTreeDataProvider.refresh();
         await buildTreeDataProvider.loadBuilds(pipeline, project);
+        
+        // Expand and focus Builds view
+        if (buildsTreeView) {
+          try {
+            await vscode.commands.executeCommand("azurePipelineBuilds.focus");
+          } catch (error) {
+            // Silently fail if command doesn't work
+          }
+        }
       }
     )
   );

--- a/src/commands/register-commands.ts
+++ b/src/commands/register-commands.ts
@@ -3,6 +3,9 @@ import { Pipeline, Project, TemplateParameters } from "../types/types";
 import { PipelineTreeDataProvider } from "../providers/pipeline/pipeline-tree-data-provider";
 import { BuildTreeDataProvider } from "../providers/build/build-tree-data-provider";
 import { StageTreeDataProvider } from "../providers/stage/stage-tree-data-provider";
+import { AccountTreeDataProvider } from "../providers/account/account-tree-data-provider";
+import { AccountManager } from "../services/account-manager";
+import { AccountData } from "../types/account";
 import { Build } from "../types/builds";
 import { TimelineRecord } from "../types/stages";
 import {
@@ -26,10 +29,177 @@ const openExternalLink = (url: string) => {
 
 export function registerCommands(
   context: vscode.ExtensionContext,
+  accountManager: AccountManager,
+  accountTreeDataProvider: AccountTreeDataProvider,
   pipelineTreeDataProvider: PipelineTreeDataProvider,
   buildTreeDataProvider: BuildTreeDataProvider,
   stageTreeDataProvider: StageTreeDataProvider
 ) {
+  // Account Commands
+  context.subscriptions.push(
+    vscode.commands.registerCommand(
+      "azurePipelinesRunner.addAccount",
+      async () => {
+        try {
+          const organization = await vscode.window.showInputBox({
+            prompt: "Enter your Azure DevOps organization name",
+            placeHolder: "Organization name",
+            validateInput: (value) => {
+              if (!value || value.trim() === "") {
+                return "Organization name is required";
+              }
+              return null;
+            },
+          });
+
+          if (!organization) {
+            return;
+          }
+
+          const pat = await vscode.window.showInputBox({
+            prompt: "Enter your Personal Access Token (PAT)",
+            placeHolder: "PAT",
+            password: true,
+            validateInput: (value) => {
+              if (!value || value.trim() === "") {
+                return "PAT is required";
+              }
+              return null;
+            },
+          });
+
+          if (!pat) {
+            return;
+          }
+
+          const note = await vscode.window.showInputBox({
+            prompt: "Enter a note to identify this account (optional)",
+            placeHolder: "e.g., Work PAT, Personal, Prod Access",
+          });
+
+          const newAccount = await vscode.window.withProgress(
+            {
+              location: vscode.ProgressLocation.Notification,
+              title: "Validating credentials...",
+              cancellable: false,
+            },
+            async () => {
+              return await accountManager.addAccount(organization.trim(), pat.trim(), note?.trim() || "");
+            }
+          );
+
+          // Automatically switch to the newly added account
+          await accountManager.setActiveAccount(newAccount.id);
+
+          vscode.window.showInformationMessage(
+            `Account added and switched to ${organization}`
+          );
+
+          // Refresh all views
+          accountTreeDataProvider.refresh();
+          pipelineTreeDataProvider.refresh();
+          buildTreeDataProvider.refresh();
+          stageTreeDataProvider.refresh();
+        } catch (error) {
+          const message = error instanceof Error ? error.message : "Unknown error";
+          vscode.window.showErrorMessage(`Failed to add account: ${message}`);
+        }
+      }
+    )
+  );
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand(
+      "azurePipelinesRunner.switchAccount",
+      async (account: AccountData) => {
+        try {
+          await accountManager.setActiveAccount(account.id);
+          vscode.window.showInformationMessage(
+            `Switched to ${account.organization} (${account.username})`
+          );
+
+          // Refresh all views
+          accountTreeDataProvider.refresh();
+          pipelineTreeDataProvider.refresh();
+          buildTreeDataProvider.refresh();
+          stageTreeDataProvider.refresh();
+        } catch (error) {
+          const message = error instanceof Error ? error.message : "Unknown error";
+          vscode.window.showErrorMessage(`Failed to switch account: ${message}`);
+        }
+      }
+    )
+  );
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand(
+      "azurePipelinesRunner.editAccountNote",
+      async (item: { account: AccountData }) => {
+        try {
+          const account = item.account;
+          const newNote = await vscode.window.showInputBox({
+            prompt: "Enter a new note for this account",
+            placeHolder: "e.g., Work PAT, Personal, Prod Access",
+            value: account.note,
+          });
+
+          if (newNote === undefined) {
+            return; // User cancelled
+          }
+
+          await accountManager.updateAccount(account.id, { note: newNote.trim() });
+          vscode.window.showInformationMessage("Account note updated");
+          accountTreeDataProvider.refresh();
+        } catch (error) {
+          const message = error instanceof Error ? error.message : "Unknown error";
+          vscode.window.showErrorMessage(`Failed to update note: ${message}`);
+        }
+      }
+    )
+  );
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand(
+      "azurePipelinesRunner.deleteAccount",
+      async (item: { account: AccountData }) => {
+        try {
+          const account = item.account;
+          const confirm = await vscode.window.showWarningMessage(
+            `Are you sure you want to delete the account for "${account.organization}" (${account.username})?`,
+            { modal: true },
+            "Delete"
+          );
+
+          if (confirm !== "Delete") {
+            return;
+          }
+
+          await accountManager.deleteAccount(account.id);
+          vscode.window.showInformationMessage("Account deleted");
+
+          // Refresh all views
+          accountTreeDataProvider.refresh();
+          pipelineTreeDataProvider.refresh();
+          buildTreeDataProvider.refresh();
+          stageTreeDataProvider.refresh();
+        } catch (error) {
+          const message = error instanceof Error ? error.message : "Unknown error";
+          vscode.window.showErrorMessage(`Failed to delete account: ${message}`);
+        }
+      }
+    )
+  );
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand(
+      "azurePipelinesRunner.refreshAccounts",
+      () => {
+        accountTreeDataProvider.refresh();
+      }
+    )
+  );
+
+  // Existing commands
   context.subscriptions.push(
     vscode.commands.registerCommand("azurePipelinesRunner.refreshEntry", () => {
       pipelineTreeDataProvider.refresh();

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -20,23 +20,22 @@ export async function activate(context: vscode.ExtensionContext) {
   const buildTreeDataProvider = new BuildTreeDataProvider();
   const stageTreeDataProvider = new StageTreeDataProvider();
 
-  // Register tree views
-  vscode.window.registerTreeDataProvider(
-    "azurePipelineAccounts",
-    accountTreeDataProvider
-  );
-  vscode.window.registerTreeDataProvider(
-    "azurePipelineView",
-    pipelineTreeDataProvider
-  );
-  vscode.window.registerTreeDataProvider(
-    "azurePipelineBuilds",
-    buildTreeDataProvider
-  );
-  vscode.window.registerTreeDataProvider(
-    "azurePipelineStages",
-    stageTreeDataProvider
-  );
+  // Create tree views with programmatic control
+  const accountsTreeView = vscode.window.createTreeView("azurePipelineAccounts", {
+    treeDataProvider: accountTreeDataProvider,
+  });
+  const pipelinesTreeView = vscode.window.createTreeView("azurePipelineView", {
+    treeDataProvider: pipelineTreeDataProvider,
+  });
+  const buildsTreeView = vscode.window.createTreeView("azurePipelineBuilds", {
+    treeDataProvider: buildTreeDataProvider,
+  });
+  const stagesTreeView = vscode.window.createTreeView("azurePipelineStages", {
+    treeDataProvider: stageTreeDataProvider,
+  });
+
+  // Store tree views in context for later use
+  context.subscriptions.push(accountsTreeView, pipelinesTreeView, buildsTreeView, stagesTreeView);
 
   // Register commands
   registerCommands(
@@ -45,14 +44,29 @@ export async function activate(context: vscode.ExtensionContext) {
     accountTreeDataProvider,
     pipelineTreeDataProvider,
     buildTreeDataProvider,
-    stageTreeDataProvider
+    stageTreeDataProvider,
+    pipelinesTreeView,
+    buildsTreeView,
+    stagesTreeView
   );
 
   // Check if any accounts exist
   const accounts = await accountManager.getAccounts();
+
   if (accounts.length === 0) {
     showWelcome();
   }
+
+  // Listen for account changes to refresh views
+  accountManager.onDidChangeAccounts(async () => {
+    const currentAccounts = await accountManager.getAccounts();
+    if (currentAccounts.length > 0) {
+      // Refresh pipelines view when first account is added
+      await vscode.commands.executeCommand("azurePipelinesRunner.refreshEntry");
+    }
+  });
 }
+
+
 
 export function deactivate() {}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2,14 +2,29 @@ import * as vscode from "vscode";
 import { PipelineTreeDataProvider } from "./providers/pipeline/pipeline-tree-data-provider";
 import { BuildTreeDataProvider } from "./providers/build/build-tree-data-provider";
 import { StageTreeDataProvider } from "./providers/stage/stage-tree-data-provider";
+import { AccountTreeDataProvider } from "./providers/account/account-tree-data-provider";
+import { AccountManager } from "./services/account-manager";
 import { showWelcome } from "./welcome";
 import { registerCommands } from "./commands/register-commands";
 
-const pipelineTreeDataProvider = new PipelineTreeDataProvider();
-const buildTreeDataProvider = new BuildTreeDataProvider();
-const stageTreeDataProvider = new StageTreeDataProvider();
+export async function activate(context: vscode.ExtensionContext) {
+  // Initialize account manager (singleton)
+  const accountManager = AccountManager.initialize(context);
 
-export function activate(context: vscode.ExtensionContext) {
+  // Attempt to migrate from legacy settings
+  await accountManager.migrateFromLegacySettings();
+
+  // Initialize tree data providers
+  const accountTreeDataProvider = new AccountTreeDataProvider(accountManager);
+  const pipelineTreeDataProvider = new PipelineTreeDataProvider();
+  const buildTreeDataProvider = new BuildTreeDataProvider();
+  const stageTreeDataProvider = new StageTreeDataProvider();
+
+  // Register tree views
+  vscode.window.registerTreeDataProvider(
+    "azurePipelineAccounts",
+    accountTreeDataProvider
+  );
   vscode.window.registerTreeDataProvider(
     "azurePipelineView",
     pipelineTreeDataProvider
@@ -23,20 +38,19 @@ export function activate(context: vscode.ExtensionContext) {
     stageTreeDataProvider
   );
 
+  // Register commands
   registerCommands(
     context,
+    accountManager,
+    accountTreeDataProvider,
     pipelineTreeDataProvider,
     buildTreeDataProvider,
     stageTreeDataProvider
   );
 
-  const organization = vscode.workspace
-    .getConfiguration()
-    .get("azurePipelinesRunner.organization");
-  const pat = vscode.workspace
-    .getConfiguration()
-    .get("azurePipelinesRunner.pat");
-  if (!organization || !pat) {
+  // Check if any accounts exist
+  const accounts = await accountManager.getAccounts();
+  if (accounts.length === 0) {
     showWelcome();
   }
 }

--- a/src/providers/account/account-item.ts
+++ b/src/providers/account/account-item.ts
@@ -1,0 +1,86 @@
+import * as vscode from "vscode";
+import { AccountData } from "../../types/account";
+
+/**
+ * Tree item representing an Azure DevOps account in the Accounts view
+ */
+export class AccountItem extends vscode.TreeItem {
+  constructor(
+    public readonly account: AccountData,
+    public readonly isActive: boolean
+  ) {
+    super(account.organization, vscode.TreeItemCollapsibleState.None);
+
+    this.contextValue = isActive ? "account-active" : "account";
+    this.description = this.getDescription();
+    this.tooltip = this.getTooltip();
+    this.iconPath = this.getIcon();
+
+    // Clicking on an account switches to it
+    this.command = {
+      command: "azurePipelinesRunner.switchAccount",
+      title: "Switch Account",
+      arguments: [account],
+    };
+  }
+
+  /**
+   * Get the description shown after the label
+   * Format: "Note (username)" or just "(username)" if no note
+   */
+  private getDescription(): string {
+    if (this.account.note) {
+      return `${this.account.note} (${this.account.username})`;
+    }
+    return `(${this.account.username})`;
+  }
+
+  /**
+   * Get the tooltip shown on hover
+   */
+  private getTooltip(): string {
+    const parts = [
+      `Organization: ${this.account.organization}`,
+      `Username: ${this.account.username}`,
+      `Display Name: ${this.account.displayName}`,
+    ];
+
+    if (this.account.note) {
+      parts.push(`Note: ${this.account.note}`);
+    }
+
+    if (this.isActive) {
+      parts.push("", "✓ Active Account");
+    }
+
+    return parts.join("\n");
+  }
+
+  /**
+   * Get the icon based on active state
+   */
+  private getIcon(): vscode.ThemeIcon {
+    if (this.isActive) {
+      return new vscode.ThemeIcon("check");
+    }
+    return new vscode.ThemeIcon("account");
+  }
+}
+
+/**
+ * Tree item for the "Add Account" action
+ */
+export class AddAccountItem extends vscode.TreeItem {
+  constructor() {
+    super("Add Account", vscode.TreeItemCollapsibleState.None);
+
+    this.contextValue = "addAccount";
+    this.iconPath = new vscode.ThemeIcon("add");
+    this.tooltip = "Add a new Azure DevOps account";
+
+    this.command = {
+      command: "azurePipelinesRunner.addAccount",
+      title: "Add Account",
+    };
+  }
+}

--- a/src/providers/account/account-tree-data-provider.ts
+++ b/src/providers/account/account-tree-data-provider.ts
@@ -1,0 +1,59 @@
+import * as vscode from "vscode";
+import { AccountManager } from "../../services/account-manager";
+import { AccountItem } from "./account-item";
+
+/**
+ * Tree data provider for the Accounts view
+ */
+export class AccountTreeDataProvider implements vscode.TreeDataProvider<vscode.TreeItem> {
+  private _onDidChangeTreeData = new vscode.EventEmitter<vscode.TreeItem | undefined | void>();
+  readonly onDidChangeTreeData = this._onDidChangeTreeData.event;
+
+  private accountManager: AccountManager;
+
+  constructor(accountManager: AccountManager) {
+    this.accountManager = accountManager;
+
+    // Listen for account changes and refresh the tree
+    this.accountManager.onDidChangeAccounts(() => {
+      this.refresh();
+    });
+  }
+
+  /**
+   * Refresh the tree view
+   */
+  refresh(): void {
+    this._onDidChangeTreeData.fire();
+  }
+
+  /**
+   * Get tree item for display
+   */
+  getTreeItem(element: vscode.TreeItem): vscode.TreeItem {
+    return element;
+  }
+
+  /**
+   * Get children of a tree item
+   */
+  async getChildren(element?: vscode.TreeItem): Promise<vscode.TreeItem[]> {
+    // Only show items at root level
+    if (element) {
+      return [];
+    }
+
+    const items: vscode.TreeItem[] = [];
+
+    // Get sorted accounts and add them
+    const accounts = await this.accountManager.getSortedAccounts();
+    const activeAccount = await this.accountManager.getActiveAccount();
+
+    for (const account of accounts) {
+      const isActive = activeAccount?.id === account.id;
+      items.push(new AccountItem(account, isActive));
+    }
+
+    return items;
+  }
+}

--- a/src/services/account-manager.ts
+++ b/src/services/account-manager.ts
@@ -1,0 +1,308 @@
+import * as vscode from "vscode";
+import { AccountData, UserInfo, ConnectionDataResponse } from "../types/account";
+import { getAxiosInstance } from "../utils/api";
+
+const STORAGE_KEY = "azurePipelinesRunner.accounts";
+const ACTIVE_ACCOUNT_KEY = "azurePipelinesRunner.activeAccountId";
+
+/**
+ * Manages Azure DevOps accounts with secure credential storage
+ */
+export class AccountManager {
+  private static instance: AccountManager | null = null;
+  private context: vscode.ExtensionContext;
+  private _onDidChangeAccounts = new vscode.EventEmitter<void>();
+  readonly onDidChangeAccounts = this._onDidChangeAccounts.event;
+
+  constructor(context: vscode.ExtensionContext) {
+    this.context = context;
+  }
+
+  /**
+   * Initialize the singleton instance
+   */
+  static initialize(context: vscode.ExtensionContext): AccountManager {
+    if (!AccountManager.instance) {
+      AccountManager.instance = new AccountManager(context);
+    }
+    return AccountManager.instance;
+  }
+
+  /**
+   * Get the singleton instance
+   */
+  static getInstance(): AccountManager {
+    if (!AccountManager.instance) {
+      throw new Error("AccountManager not initialized. Call initialize() first.");
+    }
+    return AccountManager.instance;
+  }
+
+  /**
+   * Generate a unique ID for an account
+   */
+  private generateId(): string {
+    return `${Date.now()}-${Math.random().toString(36).substring(2, 11)}`;
+  }
+
+  /**
+   * Validate credentials and fetch user info from Azure DevOps
+   */
+  async validateAndFetchAccountInfo(organization: string, pat: string): Promise<UserInfo> {
+    try {
+      const url = `https://vssps.dev.azure.com/${organization}/_apis/connectionData?api-version=7.1-preview`;
+      const response = await getAxiosInstance(pat).get<ConnectionDataResponse>(url);
+
+      const displayName = response.data.authenticatedUser.providerDisplayName;
+      const username = response.data.authenticatedUser.properties.Account.$value;
+
+      return { username, displayName };
+    } catch (error: unknown) {
+      const axiosError = error as { response?: { status?: number }; message?: string };
+      if (axiosError.response?.status === 401) {
+        throw new Error("Invalid Personal Access Token. Please check your credentials.");
+      }
+      if (axiosError.response?.status === 404) {
+        throw new Error("Organization not found. Please check the organization name.");
+      }
+      if (axiosError.message) {
+        throw new Error(`Failed to validate credentials: ${axiosError.message}`);
+      }
+      throw new Error("Failed to validate credentials. Please check your organization and PAT.");
+    }
+  }
+
+  /**
+   * Get all stored accounts
+   */
+  async getAccounts(): Promise<AccountData[]> {
+    const data = await this.context.secrets.get(STORAGE_KEY);
+    if (!data) {
+      return [];
+    }
+
+    try {
+      return JSON.parse(data) as AccountData[];
+    } catch {
+      return [];
+    }
+  }
+
+  /**
+   * Save accounts to secret storage
+   */
+  private async saveAccounts(accounts: AccountData[]): Promise<void> {
+    await this.context.secrets.store(STORAGE_KEY, JSON.stringify(accounts));
+    this._onDidChangeAccounts.fire();
+  }
+
+  /**
+   * Add a new account
+   */
+  async addAccount(organization: string, pat: string, note: string): Promise<AccountData> {
+    // Validate credentials first
+    const userInfo = await this.validateAndFetchAccountInfo(organization, pat);
+
+    const accounts = await this.getAccounts();
+
+    const newAccount: AccountData = {
+      id: this.generateId(),
+      organization,
+      pat,
+      note,
+      username: userInfo.username,
+      displayName: userInfo.displayName,
+      isActive: accounts.length === 0, // First account is automatically active
+      createdAt: new Date().toISOString(),
+    };
+
+    accounts.push(newAccount);
+    await this.saveAccounts(accounts);
+
+    // If first account, set as active
+    if (newAccount.isActive) {
+      await this.context.globalState.update(ACTIVE_ACCOUNT_KEY, newAccount.id);
+    }
+
+    return newAccount;
+  }
+
+  /**
+   * Delete an account by ID
+   */
+  async deleteAccount(accountId: string): Promise<void> {
+    const accounts = await this.getAccounts();
+    const index = accounts.findIndex((a) => a.id === accountId);
+
+    if (index === -1) {
+      throw new Error("Account not found.");
+    }
+
+    const wasActive = accounts[index].isActive;
+    accounts.splice(index, 1);
+
+    // If deleted account was active, clear the active account
+    if (wasActive) {
+      await this.context.globalState.update(ACTIVE_ACCOUNT_KEY, undefined);
+      // Optionally set another account as active
+      if (accounts.length > 0) {
+        accounts[0].isActive = true;
+        await this.context.globalState.update(ACTIVE_ACCOUNT_KEY, accounts[0].id);
+      }
+    }
+
+    await this.saveAccounts(accounts);
+  }
+
+  /**
+   * Update an account
+   */
+  async updateAccount(accountId: string, updates: Partial<Omit<AccountData, "id" | "createdAt">>): Promise<void> {
+    const accounts = await this.getAccounts();
+    const index = accounts.findIndex((a) => a.id === accountId);
+
+    if (index === -1) {
+      throw new Error("Account not found.");
+    }
+
+    accounts[index] = {
+      ...accounts[index],
+      ...updates,
+    };
+
+    await this.saveAccounts(accounts);
+  }
+
+  /**
+   * Get the currently active account
+   */
+  async getActiveAccount(): Promise<AccountData | null> {
+    const activeId = this.context.globalState.get<string>(ACTIVE_ACCOUNT_KEY);
+    const accounts = await this.getAccounts();
+
+    if (activeId) {
+      const account = accounts.find((a) => a.id === activeId);
+      if (account) {
+        return account;
+      }
+    }
+
+    // Fallback to the first account marked as active
+    const activeAccount = accounts.find((a) => a.isActive);
+    if (activeAccount) {
+      return activeAccount;
+    }
+
+    // If no active account, return the first one
+    return accounts.length > 0 ? accounts[0] : null;
+  }
+
+  /**
+   * Set an account as active
+   */
+  async setActiveAccount(accountId: string): Promise<void> {
+    const accounts = await this.getAccounts();
+    const targetAccount = accounts.find((a) => a.id === accountId);
+
+    if (!targetAccount) {
+      throw new Error("Account not found.");
+    }
+
+    // Update isActive flag for all accounts
+    for (const account of accounts) {
+      account.isActive = account.id === accountId;
+    }
+
+    await this.context.globalState.update(ACTIVE_ACCOUNT_KEY, accountId);
+    await this.saveAccounts(accounts);
+  }
+
+  /**
+   * Remove legacy credentials from settings.json
+   */
+  private async removeLegacySettings(): Promise<void> {
+    const config = vscode.workspace.getConfiguration();
+
+    // Remove from global settings.json
+    await config.update("azurePipelinesRunner.organization", undefined, vscode.ConfigurationTarget.Global);
+    await config.update("azurePipelinesRunner.pat", undefined, vscode.ConfigurationTarget.Global);
+
+    // Also remove from workspace settings if a workspace is open
+    if (vscode.workspace.workspaceFolders && vscode.workspace.workspaceFolders.length > 0) {
+      await config.update("azurePipelinesRunner.organization", undefined, vscode.ConfigurationTarget.Workspace);
+      await config.update("azurePipelinesRunner.pat", undefined, vscode.ConfigurationTarget.Workspace);
+    }
+  }
+
+  /**
+   * Migrate credentials from legacy settings.json to secure storage
+   */
+  async migrateFromLegacySettings(): Promise<boolean> {
+    const config = vscode.workspace.getConfiguration();
+    const organization = config.get<string>("azurePipelinesRunner.organization");
+    const pat = config.get<string>("azurePipelinesRunner.pat");
+
+    // Nothing to migrate if no legacy credentials
+    if (!organization || !pat) {
+      return false;
+    }
+
+    try {
+      // Validate and add account
+      const existingAccounts = await this.getAccounts();
+      const account = await this.addAccount(organization, pat, "Migrated from settings.json");
+
+      // Set as active if no other account is active
+      const hasActiveAccount = existingAccounts.some((acc) => acc.isActive);
+      if (!hasActiveAccount) {
+        await this.setActiveAccount(account.id);
+      }
+
+      // Remove legacy settings from settings.json
+      await this.removeLegacySettings();
+
+      vscode.window.showInformationMessage(
+        "Your Azure DevOps credentials have been migrated to secure storage and removed from settings.json"
+      );
+
+      return true;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Unknown error";
+      vscode.window.showErrorMessage(
+        `Failed to migrate credentials: ${message}. Please add your account manually.`
+      );
+      return false;
+    }
+  }
+
+  /**
+   * Get sorted accounts (alphabetically by org, then note, then username)
+   */
+  async getSortedAccounts(): Promise<AccountData[]> {
+    const accounts = await this.getAccounts();
+    return accounts.sort((a, b) => {
+      // Primary: Organization name
+      const orgCompare = a.organization.localeCompare(b.organization);
+      if (orgCompare !== 0) {
+        return orgCompare;
+      }
+
+      // Secondary: Note (empty notes sorted last)
+      const aNote = a.note || "\uffff"; // Use high unicode char for empty
+      const bNote = b.note || "\uffff";
+      const noteCompare = aNote.localeCompare(bNote);
+      if (noteCompare !== 0) {
+        return noteCompare;
+      }
+
+      // Tertiary: Username
+      const usernameCompare = a.username.localeCompare(b.username);
+      if (usernameCompare !== 0) {
+        return usernameCompare;
+      }
+
+      // Quaternary: Created date
+      return new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime();
+    });
+  }
+}

--- a/src/types/account.ts
+++ b/src/types/account.ts
@@ -1,0 +1,49 @@
+/**
+ * Account-related type definitions for Azure Pipelines Runner
+ */
+
+/**
+ * Represents a stored Azure DevOps account
+ */
+export interface AccountData {
+  /** Unique identifier for the account (UUID) */
+  id: string;
+  /** Azure DevOps organization name */
+  organization: string;
+  /** Personal Access Token (stored encrypted) */
+  pat: string;
+  /** User-defined identifier/note for the account */
+  note: string;
+  /** Username fetched from Azure DevOps API */
+  username: string;
+  /** Display name fetched from Azure DevOps API */
+  displayName: string;
+  /** Whether this is the currently active account */
+  isActive: boolean;
+  /** ISO timestamp of when the account was created */
+  createdAt: string;
+}
+
+/**
+ * User information fetched from Azure DevOps API
+ */
+export interface UserInfo {
+  /** Username from Azure DevOps */
+  username: string;
+  /** Display name from Azure DevOps */
+  displayName: string;
+}
+
+/**
+ * Response from Azure DevOps connection data API
+ */
+export interface ConnectionDataResponse {
+  authenticatedUser: {
+    providerDisplayName: string;
+    properties: {
+      Account: {
+        $value: string;
+      };
+    };
+  };
+}

--- a/src/utils/requests.ts
+++ b/src/utils/requests.ts
@@ -12,16 +12,20 @@ import {
 } from "../types/types";
 import { getAxiosInstance } from "./api";
 import { BuildTimeline } from "../types/stages";
+import { AccountManager } from "../services/account-manager";
 
 export async function getConfiguration() {
-  const pat = (await vscode.workspace
-    .getConfiguration()
-    .get("azurePipelinesRunner.pat")) as string;
-  const organization = (await vscode.workspace
-    .getConfiguration()
-    .get("azurePipelinesRunner.organization")) as string;
+  const accountManager = AccountManager.getInstance();
+  const activeAccount = await accountManager.getActiveAccount();
 
-  return { pat, organization };
+  if (!activeAccount) {
+    throw new Error("No active account. Please add an account first.");
+  }
+
+  return {
+    pat: activeAccount.pat,
+    organization: activeAccount.organization,
+  };
 }
 
 export async function getProjects(): Promise<Project[]> {

--- a/src/welcome.ts
+++ b/src/welcome.ts
@@ -1,34 +1,19 @@
 import * as vscode from "vscode";
 
 export async function showWelcome() {
-  const organization = await vscode.window.showInputBox({
-    prompt: "Enter your Azure DevOps organization name",
-    placeHolder: "Organization name",
-  });
+  const selection = await vscode.window.showInformationMessage(
+    "Welcome to Azure Pipelines Runner! To get started, add your Azure DevOps account using the Accounts pane.",
+    "Add Account",
+    "Learn More"
+  );
 
-  const pat = await vscode.window.showInputBox({
-    prompt: "Enter your Personal Access Token (PAT)",
-    placeHolder: "PAT",
-    password: true,
-  });
-
-  if (organization && pat) {
-    await vscode.workspace
-      .getConfiguration()
-      .update(
-        "azurePipelinesRunner.organization",
-        organization,
-        vscode.ConfigurationTarget.Global
-      );
-    await vscode.workspace
-      .getConfiguration()
-      .update(
-        "azurePipelinesRunner.pat",
-        pat,
-        vscode.ConfigurationTarget.Global
-      );
-    vscode.window.showInformationMessage("Settings saved successfully!");
-  } else {
-    vscode.window.showErrorMessage("Organization and PAT are required.");
+  if (selection === "Add Account") {
+    vscode.commands.executeCommand("azurePipelinesRunner.addAccount");
+  } else if (selection === "Learn More") {
+    vscode.env.openExternal(
+      vscode.Uri.parse(
+        "https://github.com/pedroccaetano/azure-pipeline-runner#readme"
+      )
+    );
   }
 }


### PR DESCRIPTION
## Motivation

Microsoft is [retiring global Personal Access Tokens (PATs) in Azure DevOps](https://devblogs.microsoft.com/devops/retirement-of-global-personal-access-tokens-in-azure-devops/), requiring a separate PAT for each organization. This change adds support for managing multiple PATs/accounts.

Additionally, credentials are now stored securely using VS Code's Secret Storage API instead of plaintext in `settings.json`.

## Changes

- New "Accounts" pane in the sidebar for managing Azure DevOps accounts
- Support for adding, switching, editing, and deleting accounts
- Automatic migration of existing credentials from `settings.json` to secure storage
- Credentials validated against Azure DevOps API when adding accounts

<img width="454" height="97" alt="image" src="https://github.com/user-attachments/assets/858613e9-5ff5-4e50-8fd4-357cfb62501c" />
