### PR TITLE
feat(log-viewer): add log viewer settings and file output option

### DIFF
--- a/package.json
+++ b/package.json
@@ -113,18 +113,10 @@
       },
       {
         "command": "azurePipelinesRunner.openStage",
-        "title": "Open Build",
+        "title": "Open Stage",
         "icon": {
           "light": "resources/light/browser.svg",
           "dark": "resources/dark/browser.svg"
-        }
-      },
-      {
-        "command": "azurePipelinesRunner.openStageLog",
-        "title": "Open Build",
-        "icon": {
-          "light": "resources/light/logs.svg",
-          "dark": "resources/dark/logs.svg"
         }
       },
       {
@@ -171,6 +163,11 @@
         "command": "azurePipelinesRunner.refreshAccounts",
         "title": "Refresh Accounts",
         "icon": "$(refresh)"
+      },
+      {
+        "command": "azurePipelinesRunner.toggleLogViewer",
+        "title": "Log Viewer Settings",
+        "icon": "$(ellipsis)"
       }
     ],
     "menus": {
@@ -198,7 +195,12 @@
         {
           "command": "azurePipelinesRunner.refreshStages",
           "when": "view == azurePipelineStages",
-          "group": "navigation"
+          "group": "navigation@1"
+        },
+        {
+          "command": "azurePipelinesRunner.toggleLogViewer",
+          "when": "view == azurePipelineStages",
+          "group": "navigation@2"
         },
         {
           "command": "azurePipelinesRunner.runPipelineFromBranch",
@@ -241,11 +243,6 @@
           "command": "azurePipelinesRunner.openStage",
           "when": "viewItem == stage",
           "group": "inline"
-        },
-        {
-          "command": "azurePipelinesRunner.openStageLog",
-          "when": "viewItem == stage",
-          "group": "inline"
         }
       ]
     },
@@ -270,7 +267,21 @@
     "configuration": {
       "type": "object",
       "title": "Azure Pipelines Runner",
-      "properties": {}
+      "properties": {
+        "azurePipelinesRunner.logViewer": {
+          "type": "string",
+          "enum": [
+            "outputChannel",
+            "file"
+          ],
+          "enumDescriptions": [
+            "Open logs in the Output Channel panel",
+            "Save logs to a temporary file and open in editor"
+          ],
+          "default": "outputChannel",
+          "description": "Choose how to view stage logs"
+        }
+      }
     }
   },
   "scripts": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -37,6 +37,10 @@ export async function activate(context: vscode.ExtensionContext) {
   // Store tree views in context for later use
   context.subscriptions.push(accountsTreeView, pipelinesTreeView, buildsTreeView, stagesTreeView);
 
+  // Create output channel for pipeline logs
+  const outputChannel = vscode.window.createOutputChannel("Azure Pipeline Logs");
+  context.subscriptions.push(outputChannel);
+
   // Register commands
   registerCommands(
     context,
@@ -47,7 +51,8 @@ export async function activate(context: vscode.ExtensionContext) {
     stageTreeDataProvider,
     pipelinesTreeView,
     buildsTreeView,
-    stagesTreeView
+    stagesTreeView,
+    outputChannel
   );
 
   // Check if any accounts exist

--- a/src/providers/stage/stage-item.ts
+++ b/src/providers/stage/stage-item.ts
@@ -11,6 +11,13 @@ export class StageItem extends vscode.TreeItem {
   ) {
     super(label, collapsibleState);
     this.iconPath = this.getIconPath();
+    
+    // Set command to open log when clicking on the stage item
+    this.command = {
+      command: "azurePipelinesRunner.openStageLog",
+      title: "Open Stage Log",
+      arguments: [{ timelineRecord: this.timelineRecord }]
+    };
   }
 
   private getIconPath(): { light: string; dark: string } {


### PR DESCRIPTION
- Introduced a command to toggle log viewer settings between Output Channel and File Editor.
- Updated command registration to handle log viewing preferences.
- Enhanced log retrieval to support saving logs to a temporary file.
- Modified stage item command to open logs directly from the stage.