### PR TITLE
feature: Add Auto-Refresh Polling with Configurable Settings and Status Bar Control

### DIFF
--- a/package.json
+++ b/package.json
@@ -169,6 +169,10 @@
         "title": "Log Viewer Settings",
         "icon": "$(ellipsis)"
 
+      },
+      {
+        "command": "azurePipelinesRunner.togglePolling",
+        "title": "Toggle Azure Pipelines Polling"
       }
     ],
     "menus": {

--- a/package.json
+++ b/package.json
@@ -281,6 +281,11 @@
           ],
           "default": "outputChannel",
           "description": "Choose how to view stage logs"
+        },
+        "azurePipelinesRunner.enablePolling": {
+          "type": "boolean",
+          "default": true,
+          "description": "Enable automatic polling to refresh builds and stages when they are in progress"
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -168,16 +168,7 @@
         "command": "azurePipelinesRunner.toggleLogViewer",
         "title": "Log Viewer Settings",
         "icon": "$(ellipsis)"
-      },
-      {
-        "command": "azurePipelinesRunner.toggleBuildPolling",
-        "title": "Toggle Auto-Refresh",
-        "icon": "$(sync)"
-      },
-      {
-        "command": "azurePipelinesRunner.toggleStagePolling",
-        "title": "Toggle Auto-Refresh",
-        "icon": "$(sync)"
+
       }
     ],
     "menus": {
@@ -198,38 +189,14 @@
           "group": "navigation"
         },
         {
-          "command": "azurePipelinesRunner.toggleBuildPolling",
-          "when": "view == azurePipelineBuilds && !azurePipelinesRunner.buildPollingActive",
-          "group": "navigation@2",
-          "icon": "$(sync-ignored)"
-        },
-        {
-          "command": "azurePipelinesRunner.toggleBuildPolling",
-          "when": "view == azurePipelineBuilds && azurePipelinesRunner.buildPollingActive",
-          "group": "navigation@2",
-          "icon": "$(sync)"
-        },
-        {
           "command": "azurePipelinesRunner.refreshBuilds",
           "when": "view == azurePipelineBuilds",
-          "group": "navigation@3"
-        },
-        {
-          "command": "azurePipelinesRunner.toggleStagePolling",
-          "when": "view == azurePipelineStages && !azurePipelinesRunner.stagePollingActive",
-          "group": "navigation@0",
-          "icon": "$(sync-ignored)"
-        },
-        {
-          "command": "azurePipelinesRunner.toggleStagePolling",
-          "when": "view == azurePipelineStages && azurePipelinesRunner.stagePollingActive",
-          "group": "navigation@0",
-          "icon": "$(sync)"
+          "group": "navigation@2"
         },
         {
           "command": "azurePipelinesRunner.refreshStages",
           "when": "view == azurePipelineStages",
-          "group": "navigation@1"
+          "group": "navigation@0"
         },
         {
           "command": "azurePipelinesRunner.toggleLogViewer",

--- a/package.json
+++ b/package.json
@@ -290,6 +290,13 @@
           "type": "boolean",
           "default": true,
           "description": "Enable automatic polling to refresh builds and stages when they are in progress"
+        },
+        "azurePipelinesRunner.pollingIntervalSeconds": {
+          "type": "number",
+          "default": 5,
+          "minimum": 1,
+          "maximum": 60,
+          "description": "Polling interval in seconds for refreshing builds and stages (1-60 seconds)"
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -168,6 +168,16 @@
         "command": "azurePipelinesRunner.toggleLogViewer",
         "title": "Log Viewer Settings",
         "icon": "$(ellipsis)"
+      },
+      {
+        "command": "azurePipelinesRunner.toggleBuildPolling",
+        "title": "Toggle Auto-Refresh",
+        "icon": "$(sync)"
+      },
+      {
+        "command": "azurePipelinesRunner.toggleStagePolling",
+        "title": "Toggle Auto-Refresh",
+        "icon": "$(sync)"
       }
     ],
     "menus": {
@@ -188,9 +198,33 @@
           "group": "navigation"
         },
         {
+          "command": "azurePipelinesRunner.toggleBuildPolling",
+          "when": "view == azurePipelineBuilds && !azurePipelinesRunner.buildPollingActive",
+          "group": "navigation@2",
+          "icon": "$(sync-ignored)"
+        },
+        {
+          "command": "azurePipelinesRunner.toggleBuildPolling",
+          "when": "view == azurePipelineBuilds && azurePipelinesRunner.buildPollingActive",
+          "group": "navigation@2",
+          "icon": "$(sync)"
+        },
+        {
           "command": "azurePipelinesRunner.refreshBuilds",
           "when": "view == azurePipelineBuilds",
           "group": "navigation@3"
+        },
+        {
+          "command": "azurePipelinesRunner.toggleStagePolling",
+          "when": "view == azurePipelineStages && !azurePipelinesRunner.stagePollingActive",
+          "group": "navigation@0",
+          "icon": "$(sync-ignored)"
+        },
+        {
+          "command": "azurePipelinesRunner.toggleStagePolling",
+          "when": "view == azurePipelineStages && azurePipelinesRunner.stagePollingActive",
+          "group": "navigation@0",
+          "icon": "$(sync)"
         },
         {
           "command": "azurePipelinesRunner.refreshStages",

--- a/src/commands/register-commands.ts
+++ b/src/commands/register-commands.ts
@@ -395,19 +395,6 @@ export function registerCommands(
 
   context.subscriptions.push(
     vscode.commands.registerCommand(
-      "azurePipelinesRunner.toggleBuildPolling",
-      async () => {
-        buildTreeDataProvider.togglePolling();
-        const enabled = buildTreeDataProvider.isPollingEnabled();
-        vscode.window.showInformationMessage(
-          `Build auto-refresh ${enabled ? "enabled" : "disabled"}`
-        );
-      }
-    )
-  );
-
-  context.subscriptions.push(
-    vscode.commands.registerCommand(
       "azurePipelinesRunner.loadMoreBuilds",
       async () => {
         await buildTreeDataProvider.loadMoreBuilds();
@@ -420,19 +407,6 @@ export function registerCommands(
       "azurePipelinesRunner.refreshStages",
       async () => {
         await stageTreeDataProvider.refreshStages();
-      }
-    )
-  );
-
-  context.subscriptions.push(
-    vscode.commands.registerCommand(
-      "azurePipelinesRunner.toggleStagePolling",
-      async () => {
-        stageTreeDataProvider.togglePolling();
-        const enabled = stageTreeDataProvider.isPollingEnabled();
-        vscode.window.showInformationMessage(
-          `Stage auto-refresh ${enabled ? "enabled" : "disabled"}`
-        );
       }
     )
   );

--- a/src/commands/register-commands.ts
+++ b/src/commands/register-commands.ts
@@ -395,6 +395,19 @@ export function registerCommands(
 
   context.subscriptions.push(
     vscode.commands.registerCommand(
+      "azurePipelinesRunner.toggleBuildPolling",
+      async () => {
+        buildTreeDataProvider.togglePolling();
+        const enabled = buildTreeDataProvider.isPollingEnabled();
+        vscode.window.showInformationMessage(
+          `Build auto-refresh ${enabled ? "enabled" : "disabled"}`
+        );
+      }
+    )
+  );
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand(
       "azurePipelinesRunner.loadMoreBuilds",
       async () => {
         await buildTreeDataProvider.loadMoreBuilds();
@@ -407,6 +420,19 @@ export function registerCommands(
       "azurePipelinesRunner.refreshStages",
       async () => {
         await stageTreeDataProvider.refreshStages();
+      }
+    )
+  );
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand(
+      "azurePipelinesRunner.toggleStagePolling",
+      async () => {
+        stageTreeDataProvider.togglePolling();
+        const enabled = stageTreeDataProvider.isPollingEnabled();
+        vscode.window.showInformationMessage(
+          `Stage auto-refresh ${enabled ? "enabled" : "disabled"}`
+        );
       }
     )
   );

--- a/src/commands/register-commands.ts
+++ b/src/commands/register-commands.ts
@@ -743,4 +743,19 @@ export function registerCommands(
       }
     )
   );
+
+  // Toggle Polling Command
+  context.subscriptions.push(
+    vscode.commands.registerCommand(
+      "azurePipelinesRunner.togglePolling",
+      async () => {
+        const config = vscode.workspace.getConfiguration("azurePipelinesRunner");
+        const currentValue = config.get<boolean>("enablePolling", true);
+        await config.update("enablePolling", !currentValue, vscode.ConfigurationTarget.Global);
+        
+        const status = !currentValue ? "enabled" : "disabled";
+        vscode.window.showInformationMessage(`Azure Pipelines polling ${status}`);
+      }
+    )
+  );
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -35,7 +35,26 @@ export async function activate(context: vscode.ExtensionContext) {
   });
 
   // Store tree views in context for later use
-  context.subscriptions.push(accountsTreeView, pipelinesTreeView, buildsTreeView, stagesTreeView);
+  context.subscriptions.push(
+    accountsTreeView,
+    pipelinesTreeView,
+    buildsTreeView,
+    stagesTreeView,
+    buildTreeDataProvider,
+    stageTreeDataProvider
+  );
+
+  // Initialize polling context states (both start as inactive/false)
+  vscode.commands.executeCommand(
+    "setContext",
+    "azurePipelinesRunner.buildPollingActive",
+    false
+  );
+  vscode.commands.executeCommand(
+    "setContext",
+    "azurePipelinesRunner.stagePollingActive",
+    false
+  );
 
   // Create output channel for pipeline logs
   const outputChannel = vscode.window.createOutputChannel("Azure Pipeline Logs");

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -44,6 +44,16 @@ export async function activate(context: vscode.ExtensionContext) {
     stageTreeDataProvider
   );
 
+  // Listen for view visibility changes to pause/resume polling
+  context.subscriptions.push(
+    buildsTreeView.onDidChangeVisibility((e) => {
+      buildTreeDataProvider.setViewVisible(e.visible);
+    }),
+    stagesTreeView.onDidChangeVisibility((e) => {
+      stageTreeDataProvider.setViewVisible(e.visible);
+    })
+  );
+
   // Initialize polling context states (both start as inactive/false)
   vscode.commands.executeCommand(
     "setContext",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -60,6 +60,26 @@ export async function activate(context: vscode.ExtensionContext) {
   const outputChannel = vscode.window.createOutputChannel("Azure Pipeline Logs");
   context.subscriptions.push(outputChannel);
 
+  // Create status bar item for polling toggle
+  const pollingStatusBarItem = vscode.window.createStatusBarItem(
+    vscode.StatusBarAlignment.Right,
+    100
+  );
+  pollingStatusBarItem.command = "azurePipelinesRunner.togglePolling";
+  pollingStatusBarItem.tooltip = "Toggle Azure Pipelines Polling";
+  updatePollingStatusBar(pollingStatusBarItem);
+  pollingStatusBarItem.show();
+  context.subscriptions.push(pollingStatusBarItem);
+
+  // Listen for configuration changes to update status bar
+  context.subscriptions.push(
+    vscode.workspace.onDidChangeConfiguration((e) => {
+      if (e.affectsConfiguration("azurePipelinesRunner.enablePolling")) {
+        updatePollingStatusBar(pollingStatusBarItem);
+      }
+    })
+  );
+
   // Register commands
   registerCommands(
     context,
@@ -92,5 +112,20 @@ export async function activate(context: vscode.ExtensionContext) {
 }
 
 
+
+function updatePollingStatusBar(statusBarItem: vscode.StatusBarItem) {
+  const config = vscode.workspace.getConfiguration("azurePipelinesRunner");
+  const isEnabled = config.get<boolean>("enablePolling", true);
+
+  if (isEnabled) {
+    statusBarItem.text = "$(sync)";
+    statusBarItem.tooltip = "Azure Pipelines Polling: Enabled (Click to disable)";
+  } else {
+    statusBarItem.text = "$(sync-ignored)";
+    statusBarItem.tooltip = "Azure Pipelines Polling: Disabled (Click to enable)";
+  }
+  
+  statusBarItem.show();
+}
 
 export function deactivate() {}

--- a/src/providers/build/build-tree-data-provider.ts
+++ b/src/providers/build/build-tree-data-provider.ts
@@ -22,7 +22,6 @@ export class BuildTreeDataProvider
   private currentProject?: Project;
   private pollingIntervalId: NodeJS.Timeout | undefined;
   private readonly POLLING_INTERVAL = 5000; // 5 seconds
-  private pollingEnabled: boolean = true;
 
   constructor() {}
 
@@ -75,13 +74,10 @@ export class BuildTreeDataProvider
   }
 
   private updatePollingState(): void {
-    if (this.pollingEnabled && this.shouldPoll() && !this.pollingIntervalId) {
+    if (this.shouldPoll() && !this.pollingIntervalId) {
       this.startPolling();
-    } else if ((!this.pollingEnabled || !this.shouldPoll()) && this.pollingIntervalId) {
+    } else if (!this.shouldPoll() && this.pollingIntervalId) {
       this.stopPolling();
-    } else if (!this.pollingEnabled || !this.shouldPoll()) {
-      // Ensure context is updated even if we weren't polling
-      this.updateContextState(false);
     }
   }
 
@@ -91,20 +87,6 @@ export class BuildTreeDataProvider
       "azurePipelinesRunner.buildPollingActive",
       active
     );
-  }
-
-  public togglePolling(): void {
-    this.pollingEnabled = !this.pollingEnabled;
-    if (this.pollingEnabled) {
-      this.updatePollingState();
-    } else {
-      this.stopPolling();
-      this.updateContextState(false);
-    }
-  }
-
-  public isPollingEnabled(): boolean {
-    return this.pollingEnabled;
   }
 
   dispose(): void {

--- a/src/providers/build/build-tree-data-provider.ts
+++ b/src/providers/build/build-tree-data-provider.ts
@@ -22,6 +22,7 @@ export class BuildTreeDataProvider
   private currentProject?: Project;
   private pollingIntervalId: NodeJS.Timeout | undefined;
   private configChangeListener: vscode.Disposable | undefined;
+  private isViewVisible: boolean = true;
 
   constructor() {
     // Listen for configuration changes
@@ -31,6 +32,24 @@ export class BuildTreeDataProvider
         this.updatePollingState();
       }
     });
+  }
+
+  setViewVisible(visible: boolean): void {
+    this.isViewVisible = visible;
+    this.updatePollingState();
+  }
+
+  pausePolling(): void {
+    if (this.pollingIntervalId) {
+      clearInterval(this.pollingIntervalId);
+      this.pollingIntervalId = undefined;
+    }
+  }
+
+  resumePolling(): void {
+    if (this.shouldPoll() && !this.pollingIntervalId) {
+      this.startPolling();
+    }
   }
 
   getCurrentPipeline(): Pipeline | undefined {
@@ -51,7 +70,7 @@ export class BuildTreeDataProvider
     const config = vscode.workspace.getConfiguration("azurePipelinesRunner");
     const pollingEnabled = config.get<boolean>("enablePolling", true);
 
-    if (!pollingEnabled) {
+    if (!pollingEnabled || !this.isViewVisible) {
       return false;
     }
 

--- a/src/providers/stage/stage-item.ts
+++ b/src/providers/stage/stage-item.ts
@@ -62,7 +62,7 @@ export class StageItem extends vscode.TreeItem {
         };
       default:
         if (this.timelineRecord.state === "inProgress") {
-          iconName = "clock.svg";
+          iconName = "inProgress.svg";
           break;
         }
 

--- a/src/providers/stage/stage-item.ts
+++ b/src/providers/stage/stage-item.ts
@@ -12,12 +12,14 @@ export class StageItem extends vscode.TreeItem {
     super(label, collapsibleState);
     this.iconPath = this.getIconPath();
     
-    // Set command to open log when clicking on the stage item
-    this.command = {
-      command: "azurePipelinesRunner.openStageLog",
-      title: "Open Stage Log",
-      arguments: [{ timelineRecord: this.timelineRecord }]
-    };
+    // Only set command for tasks (which have logs), not for stages or jobs
+    if (this.timelineRecord.type === "Task" && this.timelineRecord.log) {
+      this.command = {
+        command: "azurePipelinesRunner.openStageLog",
+        title: "Open Task Log",
+        arguments: [{ timelineRecord: this.timelineRecord }]
+      };
+    }
   }
 
   private getIconPath(): { light: string; dark: string } {

--- a/src/providers/stage/stage-tree-data-provider.ts
+++ b/src/providers/stage/stage-tree-data-provider.ts
@@ -24,6 +24,7 @@ export class StageTreeDataProvider
   private pollingIntervalId: NodeJS.Timeout | undefined;
   private readonly POLLING_INTERVAL = 5000; // 5 seconds
   private configChangeListener: vscode.Disposable | undefined;
+  private isViewVisible: boolean = true;
 
   constructor() {
     // Listen for configuration changes
@@ -32,6 +33,24 @@ export class StageTreeDataProvider
         this.updatePollingState();
       }
     });
+  }
+
+  setViewVisible(visible: boolean): void {
+    this.isViewVisible = visible;
+    this.updatePollingState();
+  }
+
+  pausePolling(): void {
+    if (this.pollingIntervalId) {
+      clearInterval(this.pollingIntervalId);
+      this.pollingIntervalId = undefined;
+    }
+  }
+
+  resumePolling(): void {
+    if (this.shouldPoll() && !this.pollingIntervalId) {
+      this.startPolling();
+    }
   }
 
   refresh(): void {
@@ -44,7 +63,7 @@ export class StageTreeDataProvider
     const config = vscode.workspace.getConfiguration("azurePipelinesRunner");
     const pollingEnabled = config.get<boolean>("enablePolling", true);
 
-    if (!pollingEnabled) {
+    if (!pollingEnabled || !this.isViewVisible) {
       return false;
     }
 

--- a/src/providers/stage/stage-tree-data-provider.ts
+++ b/src/providers/stage/stage-tree-data-provider.ts
@@ -23,7 +23,6 @@ export class StageTreeDataProvider
   private build: Build | undefined = undefined;
   private pollingIntervalId: NodeJS.Timeout | undefined;
   private readonly POLLING_INTERVAL = 5000; // 5 seconds
-  private pollingEnabled: boolean = true;
 
   refresh(): void {
     this.records = [];
@@ -62,13 +61,10 @@ export class StageTreeDataProvider
   }
 
   private updatePollingState(): void {
-    if (this.pollingEnabled && this.shouldPoll() && !this.pollingIntervalId) {
+    if (this.shouldPoll() && !this.pollingIntervalId) {
       this.startPolling();
-    } else if ((!this.pollingEnabled || !this.shouldPoll()) && this.pollingIntervalId) {
+    } else if (!this.shouldPoll() && this.pollingIntervalId) {
       this.stopPolling();
-    } else if (!this.pollingEnabled || !this.shouldPoll()) {
-      // Ensure context is updated even if we weren't polling
-      this.updateContextState(false);
     }
   }
 
@@ -78,20 +74,6 @@ export class StageTreeDataProvider
       "azurePipelinesRunner.stagePollingActive",
       active
     );
-  }
-
-  public togglePolling(): void {
-    this.pollingEnabled = !this.pollingEnabled;
-    if (this.pollingEnabled) {
-      this.updatePollingState();
-    } else {
-      this.stopPolling();
-      this.updateContextState(false);
-    }
-  }
-
-  public isPollingEnabled(): boolean {
-    return this.pollingEnabled;
   }
 
   dispose(): void {


### PR DESCRIPTION
## Overview

Auto-refresh functionality for builds and stages with configurable polling settings and a status bar control.

## Key Features

### 🔄 Auto-Refresh Polling
- Automatic polling of builds and stages only when there is an active build or stage
- Smart pause/resume when extension views are hidden/shown

### ⚙️ Configuration Settings
- **Enable/Disable Polling**: `azurePipelinesRunner.enablePolling` setting to control auto-refresh
- **Configurable Interval**: `azurePipelinesRunner.pollingIntervalSeconds` setting (1-60 seconds, default: 5)

### 🎮 Status Bar Control
- Status bar item showing polling status
- Quick toggle command via command palette
- Visual indicator of current polling state

### 🎯 UI Improvements
- Updated in-progress stage icon for better clarity (clock → inProgress)