### PR TITLE
feature: Add commands to open Job and Task links

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,6 +102,16 @@
         "icon": "$(link-external)"
       },
       {
+        "command": "azurePipelinesRunner.openJob",
+        "title": "Open Job",
+        "icon": "$(link-external)"
+      },
+      {
+        "command": "azurePipelinesRunner.openTask",
+        "title": "Open Task",
+        "icon": "$(link-external)"
+      },
+      {
         "command": "azurePipelinesRunner.retryStage",
         "title": "Retry Stage",
         "icon": "$(redo)"
@@ -313,6 +323,16 @@
           "command": "azurePipelinesRunner.openStage",
           "when": "viewItem == stage || viewItem == stage-stopped",
           "group": "inline@2"
+        },
+        {
+          "command": "azurePipelinesRunner.openJob",
+          "when": "viewItem == phase",
+          "group": "inline@1"
+        },
+        {
+          "command": "azurePipelinesRunner.openTask",
+          "when": "viewItem == task",
+          "group": "inline@1"
         }
       ]
     },

--- a/src/commands/register-commands.ts
+++ b/src/commands/register-commands.ts
@@ -364,6 +364,41 @@ export function registerCommands(
 
   context.subscriptions.push(
     vscode.commands.registerCommand(
+      "azurePipelinesRunner.openJob",
+      async ({ timelineRecord }: { timelineRecord: TimelineRecord }) => {
+        const { organization } = await getConfiguration();
+
+        // Find the Job child of this Phase to get the correct job ID for the URL
+        const allRecords = stageTreeDataProvider.getAllRecords();
+        const jobChild = allRecords.find(
+          (r) => r.type === "Job" && r.parentId === timelineRecord.id
+        );
+
+        // Use the Job ID if found, otherwise fall back to the Phase ID
+        const jobId = jobChild?.id ?? timelineRecord.id;
+        const url = `https://dev.azure.com/${organization}/${timelineRecord.projectName}/_build/results?buildId=${timelineRecord.buildId}&view=logs&j=${jobId}`;
+
+        openExternalLink(url);
+      }
+    )
+  );
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand(
+      "azurePipelinesRunner.openTask",
+      async ({ timelineRecord }: { timelineRecord: TimelineRecord }) => {
+        const { organization } = await getConfiguration();
+
+        // For tasks, use j= for the parent job and t= for the task
+        const url = `https://dev.azure.com/${organization}/${timelineRecord.projectName}/_build/results?buildId=${timelineRecord.buildId}&view=logs&j=${timelineRecord.parentId}&t=${timelineRecord.id}`;
+
+        openExternalLink(url);
+      }
+    )
+  );
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand(
       "azurePipelinesRunner.openStageLog",
       async ({ timelineRecord }: { timelineRecord: TimelineRecord }) => {
         try {


### PR DESCRIPTION
Enhances navigation by allowing users to open specific Job and Task logs directly.

- Added command to open Job logs using timeline record
- Added command to open Task logs using timeline record
- Updated package.json to include new commands in the UI